### PR TITLE
Fix image cleanup timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The link mapper is integrated into the main conversion workflow and uses a two-s
 Images are now automatically moved to a `static` directory located next to the
 output docs. All references inside Markdown files are updated, preserving
 relative paths and directory structure. No additional flags are required.
+Missing image references are cleaned up after conversion so broken links don't remain.
 
 ## Features
 
@@ -29,6 +30,7 @@ relative paths and directory structure. No additional flags are required.
 - Convert Flare-specific UI elements to Docusaurus equivalents (admonitions, expandable sections, etc.)
 - Generate Docusaurus sidebar configuration
 - Automatically relocate images to a `static` directory next to your docs
+- Remove references to images that are missing after conversion
 
 ## Installation
 

--- a/flarewell/cli.py
+++ b/flarewell/cli.py
@@ -14,6 +14,7 @@ from typing import Optional, List
 from flarewell.converter import FlareConverter
 from flarewell.link_mapper import LinkMapper
 from flarewell.image_relocator import ImageRelocator
+from flarewell.markdown_image_cleaner import MarkdownImageCleaner
 
 
 @click.group()
@@ -222,6 +223,15 @@ def convert(
 
     if relocation_stats['errors'] > 0:
         click.echo(f"❌ {relocation_stats['errors']} errors encountered during image relocation.")
+
+    # Remove references to images that do not exist
+    click.echo("\nCleaning up references to missing images...")
+    cleanup_start = time.time()
+    cleaner = MarkdownImageCleaner(output_dir, debug=debug)
+    cleanup_stats = cleaner.clean()
+    cleanup_time = time.time() - cleanup_start
+    click.echo(f"✅ Image cleanup completed in {cleanup_time:.2f} seconds.")
+    click.echo(f"References removed: {cleanup_stats['references_removed']}")
     
     # Print total time
     total_time = time.time() - start_time

--- a/flarewell/flare_parser.py
+++ b/flarewell/flare_parser.py
@@ -128,7 +128,8 @@ class FlareHtmlParser(FlareParserBase):
             
             body_content = str(main_content) if main_content else str(soup.body)
             
-            # Find all images and resources, removing references that don't exist
+            # Find all images and resources
+            # Do not remove missing images here; collect them for post-processing
             images = []
             missing_images = []
             if main_content:
@@ -138,13 +139,11 @@ class FlareHtmlParser(FlareParserBase):
                         continue
 
                     normalized_src = src.replace("\\", "/")
-                    img_path = (self.input_dir / normalized_src).resolve()
+                    images.append(normalized_src)
 
-                    if img_path.exists():
-                        images.append(normalized_src)
-                    else:
+                    img_path = (self.input_dir / normalized_src).resolve()
+                    if not img_path.exists():
                         missing_images.append(normalized_src)
-                        img.decompose()
             
             return {
                 "title": title_text,

--- a/flarewell/markdown_image_cleaner.py
+++ b/flarewell/markdown_image_cleaner.py
@@ -1,0 +1,63 @@
+import os
+import re
+from pathlib import Path
+from typing import Dict
+
+class MarkdownImageCleaner:
+    """Scan markdown files and remove references to images that do not exist."""
+
+    def __init__(self, docs_dir: str, debug: bool = False):
+        self.docs_dir = Path(docs_dir)
+        self.debug = debug
+
+    def clean(self) -> Dict[str, int]:
+        removed = 0
+        md_files = list(self.docs_dir.glob("**/*.md"))
+        for md_file in md_files:
+            with open(md_file, "r", encoding="utf-8") as f:
+                content = f.read()
+            updated_content, count = self._remove_missing(content, md_file)
+            if count > 0:
+                with open(md_file, "w", encoding="utf-8") as f:
+                    f.write(updated_content)
+                removed += count
+        return {"references_removed": removed}
+
+    def _remove_missing(self, text: str, md_file: Path):
+        count = 0
+
+        def repl_md(match):
+            nonlocal count
+            img_path = match.group(2)
+            img_path_clean = img_path.split()[0].replace('\\', '/').strip()
+            if img_path_clean.startswith(('http://', 'https://')):
+                return match.group(0)
+            abs_path = (md_file.parent / img_path_clean).resolve()
+            if not abs_path.exists():
+                if self.debug:
+                    print(f"Removing missing image '{img_path_clean}' in {md_file}")
+                count += 1
+                return ''
+            return match.group(0)
+
+        md_image_pattern = r'!\[([^\]]*)\]\(([^)]+)\)'
+        text = re.sub(md_image_pattern, repl_md, text)
+
+        def repl_html(match):
+            nonlocal count
+            img_path = match.group(1)
+            img_path_clean = img_path.replace('\\', '/').strip()
+            if img_path_clean.startswith(('http://', 'https://')):
+                return match.group(0)
+            abs_path = (md_file.parent / img_path_clean).resolve()
+            if not abs_path.exists():
+                if self.debug:
+                    print(f"Removing missing image '{img_path_clean}' in {md_file}")
+                count += 1
+                return ''
+            return match.group(0)
+
+        html_img_pattern = r'<img[^>]+src="([^"]+)"[^>]*>'
+        text = re.sub(html_img_pattern, repl_html, text)
+
+        return text, count


### PR DESCRIPTION
## Summary
- keep image tags during parsing and note missing images
- scan markdown output for missing images and remove references
- call cleaner from CLI after relocation
- document new behavior

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*