### PR TITLE
Remove Resources from asset paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Missing image references are removed during a post-conversion scan of the genera
 - Convert Flare-specific UI elements to Docusaurus equivalents (admonitions, expandable sections, etc.)
 - Generate Docusaurus sidebar configuration
 - Automatically relocate images to a `static` directory next to your docs
+- Image filenames with spaces are stored using underscores in the output
 - Remove references to images that are missing after conversion
 
 ## Installation

--- a/flarewell/converter.py
+++ b/flarewell/converter.py
@@ -223,13 +223,18 @@ class FlareConverter:
         """
         for asset in assets:
             source_path = self.input_dir / asset.get("path", "")
-            
+
             if self.preserve_structure:
-                rel_path = asset.get("rel_path", asset.get("path", ""))
+                rel_path = Path(asset.get("rel_path", asset.get("path", "")))
+                # Drop any leading 'Resources' directory from the asset path
+                rel_parts = [p for p in rel_path.parts if p.lower() != "resources"]
+                rel_path = Path(*rel_parts)
                 dest_path = self.output_dir / rel_path
             else:
                 # Use new path if provided by LLM
-                dest_path = self.output_dir / asset.get("new_path", asset.get("rel_path", ""))
+                new_path = Path(asset.get("new_path", asset.get("rel_path", "")))
+                rel_parts = [p for p in new_path.parts if p.lower() != "resources"]
+                dest_path = self.output_dir / Path(*rel_parts)
             
             # Create parent directories
             os.makedirs(dest_path.parent, exist_ok=True)

--- a/flarewell/image_relocator.py
+++ b/flarewell/image_relocator.py
@@ -73,13 +73,20 @@ class ImageRelocator:
             try:
                 # Get the path relative to the source directory
                 rel_path = source_path.relative_to(self.source_dir)
-                
+
+                # Remove any 'Resources' directory from the relative path
+                rel_parts = [p for p in rel_path.parts if p.lower() != "resources"]
+                rel_path_no_res = Path(*rel_parts)
+
                 if self.preserve_structure:
-                    # Keep subdirectory structure but place in target directory
-                    target_path = self.target_dir / rel_path
+                    # Keep subdirectory structure without the Resources folder
+                    target_path = self.target_dir / rel_path_no_res
                 else:
                     # Flatten structure, just keep filename
                     target_path = self.target_dir / source_path.name
+
+                # Replace spaces in filenames with underscores
+                target_path = target_path.with_name(target_path.name.replace(" ", "_"))
                 
                 # Create parent directories if they don't exist
                 os.makedirs(target_path.parent, exist_ok=True)
@@ -88,13 +95,15 @@ class ImageRelocator:
                 shutil.copy2(source_path, target_path)
                 
                 # Store the mapping for updating references
-                # For the key, use the relative path from source directory
-                key = str(rel_path)
-                
+                # Include both the original path and the path without 'Resources'
+                key_original = str(rel_path).replace("\\", "/")
+                key_no_res = str(rel_path_no_res).replace("\\", "/")
+
                 # For the value, calculate the relative path from source_dir to target_path
                 # This ensures consistent path resolution regardless of absolute paths
                 target_rel_path = os.path.relpath(target_path, self.source_dir)
-                self.relocated_images[key] = target_rel_path
+                self.relocated_images[key_original] = target_rel_path
+                self.relocated_images[key_no_res] = target_rel_path
                 
                 stats["images_relocated"] += 1
                 
@@ -217,8 +226,13 @@ class ImageRelocator:
             abs_path = os.path.normpath(os.path.join(current_dir, img_path)).replace('\\', '/')
         
         # Check if this image was relocated
-        if abs_path in self.relocated_images:
-            new_path = self.relocated_images[abs_path]
+        lookup_path = abs_path
+        if abs_path not in self.relocated_images and 'Resources/' in abs_path:
+            # Try again without the Resources folder
+            lookup_path = abs_path.replace('Resources/', '', 1)
+
+        if lookup_path in self.relocated_images:
+            new_path = self.relocated_images[lookup_path]
             
             # Calculate relative path from current file to the new image location
             try:

--- a/flarewell/markdown_image_cleaner.py
+++ b/flarewell/markdown_image_cleaner.py
@@ -29,7 +29,12 @@ class MarkdownImageCleaner:
         def repl_md(match):
             nonlocal count
             img_path = match.group(2)
-            img_path_clean = img_path.split()[0].replace('\\', '/').strip()
+            # Remove optional title after the path
+            title_match = re.search(r'\s+"[^"]*"$', img_path)
+            if title_match:
+                img_path = img_path[:title_match.start()].strip()
+
+            img_path_clean = img_path.replace('\\', '/').strip()
             if img_path_clean.startswith(('http://', 'https://')):
                 return match.group(0)
             abs_path = (md_file.parent / img_path_clean).resolve()
@@ -40,7 +45,7 @@ class MarkdownImageCleaner:
                 return ''
             return match.group(0)
 
-        md_image_pattern = r'!\[([^\]]*)\]\(([^)]+)\)'
+        md_image_pattern = r'!\[([^\]]*)\]\(([^)]+)\s*(?:"[^"]*")?\)'
         text = re.sub(md_image_pattern, repl_md, text)
 
         def repl_html(match):


### PR DESCRIPTION
## Summary
- skip the `Resources` directory when copying asset files
- drop `Resources` from image relocation paths and update reference logic
- handle spaces in image filenames

## Testing
- `python -m py_compile flarewell/image_relocator.py flarewell/markdown_image_cleaner.py flarewell/converter.py`
