### PR TITLE
Remove Resources from asset paths

### DIFF
--- a/flarewell/cli.py
+++ b/flarewell/cli.py
@@ -37,31 +37,25 @@ def cli():
     help="Directory to output Docusaurus-compatible Markdown files."
 )
 @click.option(
-    "--use-llm",
-    is_flag=True,
-    help="Use LLM to suggest an improved folder/file structure."
-)
-@click.option(
-    "--llm-api-key",
-    envvar="FLAREWELL_LLM_API_KEY",
-    help="API key for the LLM service (can also be set via FLAREWELL_LLM_API_KEY environment variable)."
-)
-@click.option(
-    "--llm-provider",
-    type=click.Choice(["openai", "anthropic"]),
-    default="openai",
-    help="LLM provider to use when --use-llm is specified."
-)
-@click.option(
     "--preserve-structure",
     is_flag=True,
     default=True,
     help="Preserve the original folder/file structure."
 )
 @click.option(
+    "--no-sidebars",
+    is_flag=True,
+    help="Skip sidebar.js generation."
+)
+@click.option(
     "--exclude-dir",
     multiple=True,
     help="Directory patterns to exclude from conversion (can be used multiple times)."
+)
+@click.option(
+    "--verbose-image-cleanup",
+    is_flag=True,
+    help="Print each removed image reference and deleted file."
 )
 @click.option(
     "--debug",
@@ -83,11 +77,10 @@ def cli():
 def convert(
     input_dir: str,
     output_dir: str,
-    use_llm: bool,
-    llm_api_key: Optional[str],
-    llm_provider: str,
+    no_sidebars: bool,
     preserve_structure: bool,
     exclude_dir: List[str],
+    verbose_image_cleanup: bool,
     debug: bool,
     markdown_style: str,
 ):
@@ -103,9 +96,7 @@ def convert(
         input_dir=input_dir,
         output_dir=output_dir,
         preserve_structure=preserve_structure,
-        use_llm=use_llm,
-        llm_api_key=llm_api_key,
-        llm_provider=llm_provider,
+        generate_sidebars=not no_sidebars,
         exclude_dirs=exclude_dir,
         debug=debug,
         markdown_style=markdown_style,
@@ -227,7 +218,7 @@ def convert(
     # Remove references to images that do not exist
     click.echo("\nCleaning up references to missing images...")
     cleanup_start = time.time()
-    cleaner = MarkdownImageCleaner(output_dir, debug=debug)
+    cleaner = MarkdownImageCleaner(output_dir, static_dir, debug=verbose_image_cleanup)
     cleanup_stats = cleaner.clean()
     cleanup_time = time.time() - cleanup_start
     click.echo(f"✅ Image cleanup completed in {cleanup_time:.2f} seconds.")

--- a/flarewell/markdown_image_cleaner.py
+++ b/flarewell/markdown_image_cleaner.py
@@ -1,30 +1,56 @@
 import os
 import re
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, Set
 
 class MarkdownImageCleaner:
     """Scan markdown files and remove references to images that do not exist."""
 
-    def __init__(self, docs_dir: str, debug: bool = False):
+    def __init__(self, docs_dir: str, static_dir: str, debug: bool = False):
         self.docs_dir = Path(docs_dir)
+        self.static_dir = Path(static_dir)
         self.debug = debug
 
     def clean(self) -> Dict[str, int]:
         removed = 0
+        removed_files = 0
+        all_refs: Set[str] = set()
+        details: Dict[str, List[str]] = {}
+
         md_files = list(self.docs_dir.glob("**/*.md"))
         for md_file in md_files:
             with open(md_file, "r", encoding="utf-8") as f:
                 content = f.read()
-            updated_content, count = self._remove_missing(content, md_file)
+            updated_content, count, refs = self._remove_missing(content, md_file)
+            all_refs.update(refs)
             if count > 0:
                 with open(md_file, "w", encoding="utf-8") as f:
                     f.write(updated_content)
                 removed += count
-        return {"references_removed": removed}
+                if self.debug:
+                    details[str(md_file.relative_to(self.docs_dir))] = refs
+
+        # Delete unreferenced images from static dir
+        image_exts = [".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp", ".tiff"]
+        for img_file in self.static_dir.rglob("*"):
+            if img_file.suffix.lower() in image_exts and img_file.is_file():
+                rel = str(img_file.relative_to(self.docs_dir.parent)).replace("\\", "/")
+                if rel not in all_refs and rel.lower() not in {r.lower() for r in all_refs}:
+                    if self.debug:
+                        print(f"Deleting unreferenced image '{rel}'")
+                    img_file.unlink()
+                    removed_files += 1
+
+        if self.debug:
+            for file, refs in details.items():
+                for ref in refs:
+                    print(f"Removed '{ref}' from {file}")
+
+        return {"references_removed": removed, "images_deleted": removed_files}
 
     def _remove_missing(self, text: str, md_file: Path):
         count = 0
+        removed: List[str] = []
 
         def repl_md(match):
             nonlocal count
@@ -37,10 +63,11 @@ class MarkdownImageCleaner:
                 if self.debug:
                     print(f"Removing missing image '{img_path_clean}' in {md_file}")
                 count += 1
+                removed.append(img_path_clean)
                 return ''
             return match.group(0)
 
-        md_image_pattern = r'!\[([^\]]*)\]\(([^)]+)\)'
+        md_image_pattern = r'!\[([^\]]*)\]\(([^)]+)\s*(?:"[^"]*")?\)'
         text = re.sub(md_image_pattern, repl_md, text)
 
         def repl_html(match):
@@ -54,10 +81,11 @@ class MarkdownImageCleaner:
                 if self.debug:
                     print(f"Removing missing image '{img_path_clean}' in {md_file}")
                 count += 1
+                removed.append(img_path_clean)
                 return ''
             return match.group(0)
 
         html_img_pattern = r'<img[^>]+src="([^"]+)"[^>]*>'
         text = re.sub(html_img_pattern, repl_html, text)
 
-        return text, count
+        return text, count, removed


### PR DESCRIPTION
## Summary
- skip the `Resources` directory when copying asset files
- drop `Resources` from image relocation paths and update reference logic
- default to generating a sidebar, remove LLM support
- sanitize markdown and frontmatter titles, quoting the title
- support verbose image cleanup with removal of unused files

## Testing
- `python -m py_compile flarewell/cli.py flarewell/converter.py flarewell/image_relocator.py flarewell/markdown_image_cleaner.py flarewell/docusaurus_formatter.py flarewell/link_mapper.py flarewell/flare_parser.py`