### PR TITLE
Remove LLM code and restore image cleaner helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Missing image references are removed during a post-conversion scan of the genera
 ## Features
 
 - Convert Flare HTML output to Markdown
-- Maintain folder/file structure or suggest an improved structure using LLM
+- Preserve the original folder structure and automatically generate `sidebars.js`
 - Convert Flare-specific UI elements to Docusaurus equivalents (admonitions, expandable sections, etc.)
 - Generate Docusaurus sidebar configuration
 - Automatically relocate images to a `static` directory next to your docs
@@ -67,32 +67,15 @@ flarewell convert --input-dir /path/to/flare/html --output-dir ./docs --markdown
 
 Converted images will be moved to a `static` directory next to your output docs automatically.
 
-
-#### Using LLM for Structure Suggestions
-
-To use an LLM to suggest an improved folder/file structure:
-
-```bash
-flarewell convert --input-dir /path/to/flare/html --output-dir /path/to/docusaurus/docs --use-llm --llm-api-key YOUR_API_KEY
-```
-
-You can also set your API key via environment variable:
-
-```bash
-export FLAREWELL_LLM_API_KEY=YOUR_API_KEY
-flarewell convert --input-dir /path/to/flare/html --output-dir /path/to/docusaurus/docs --use-llm
-```
-
 #### Convert Options
 
 - `--input-dir, -i`: Directory containing Flare HTML output
 - `--output-dir, -o`: Directory to output Docusaurus-compatible Markdown files
 - `--preserve-structure`: Preserve the original folder/file structure (default: `True`)
-- `--use-llm`: Use LLM to suggest an improved folder/file structure
-- `--llm-api-key`: API key for the LLM service (or set via `FLAREWELL_LLM_API_KEY` environment variable)
-- `--llm-provider`: LLM provider to use (`openai` or `anthropic`), default is `openai`
 - `--exclude-dir`: Directory patterns to exclude from conversion (can be used multiple times)
 - `--debug`: Enable debug mode for detailed logging
+- `--no-sidebars`: Skip generating `sidebars.js`
+- `--verbose-image-cleanup`: Print each removed image reference
 - 
 ## Development
 

--- a/flarewell/cli.py
+++ b/flarewell/cli.py
@@ -37,22 +37,6 @@ def cli():
     help="Directory to output Docusaurus-compatible Markdown files."
 )
 @click.option(
-    "--use-llm",
-    is_flag=True,
-    help="Use LLM to suggest an improved folder/file structure."
-)
-@click.option(
-    "--llm-api-key",
-    envvar="FLAREWELL_LLM_API_KEY",
-    help="API key for the LLM service (can also be set via FLAREWELL_LLM_API_KEY environment variable)."
-)
-@click.option(
-    "--llm-provider",
-    type=click.Choice(["openai", "anthropic"]),
-    default="openai",
-    help="LLM provider to use when --use-llm is specified."
-)
-@click.option(
     "--preserve-structure",
     is_flag=True,
     default=True,
@@ -75,20 +59,23 @@ def cli():
     help="Output style for converted files."
 )
 @click.option(
-    "--markdown-style",
-    type=click.Choice(["docusaurus", "markdown"]),
-    default="docusaurus",
-    help="Output style for converted files."
+    "--no-sidebars",
+    is_flag=True,
+    help="Skip sidebars.js generation."
+)
+@click.option(
+    "--verbose-image-cleanup",
+    is_flag=True,
+    help="Print details about removed image references."
 )
 def convert(
     input_dir: str,
     output_dir: str,
-    use_llm: bool,
-    llm_api_key: Optional[str],
-    llm_provider: str,
     preserve_structure: bool,
     exclude_dir: List[str],
     debug: bool,
+    no_sidebars: bool,
+    verbose_image_cleanup: bool,
     markdown_style: str,
 ):
     """Convert MadCap Flare HTML output to Docusaurus-compatible Markdown."""
@@ -103,9 +90,7 @@ def convert(
         input_dir=input_dir,
         output_dir=output_dir,
         preserve_structure=preserve_structure,
-        use_llm=use_llm,
-        llm_api_key=llm_api_key,
-        llm_provider=llm_provider,
+        generate_sidebars=not no_sidebars,
         exclude_dirs=exclude_dir,
         debug=debug,
         markdown_style=markdown_style,
@@ -227,7 +212,7 @@ def convert(
     # Remove references to images that do not exist
     click.echo("\nCleaning up references to missing images...")
     cleanup_start = time.time()
-    cleaner = MarkdownImageCleaner(output_dir, debug=debug)
+    cleaner = MarkdownImageCleaner(output_dir, debug=verbose_image_cleanup)
     cleanup_stats = cleaner.clean()
     cleanup_time = time.time() - cleanup_start
     click.echo(f"✅ Image cleanup completed in {cleanup_time:.2f} seconds.")

--- a/flarewell/converter.py
+++ b/flarewell/converter.py
@@ -15,7 +15,6 @@ import yaml
 from flarewell.flare_parser import FlareHtmlParser
 from flarewell.docusaurus_formatter import DocusaurusFormatter
 from flarewell.link_mapper import LinkMapper
-from flarewell.llm_service import LlmService
 from flarewell.markdown_image_cleaner import MarkdownImageCleaner
 
 
@@ -27,9 +26,7 @@ class FlareConverter:
         input_dir: str,
         output_dir: str,
         preserve_structure: bool = True,
-        use_llm: bool = False,
-        llm_api_key: Optional[str] = None,
-        llm_provider: str = "openai",
+        generate_sidebars: bool = True,
         exclude_dirs: Optional[List[str]] = None,
         debug: bool = False,
         markdown_style: str = "docusaurus",
@@ -42,9 +39,7 @@ class FlareConverter:
             input_type: Either ``"project"`` or ``"html"``.
             preserve_structure: Mirror the input directory structure in the
                 output directory.
-            use_llm: Whether to call an LLM for structure suggestions.
-            llm_api_key: API key for the LLM if ``use_llm`` is ``True``.
-            llm_provider: LLM provider name.
+            generate_sidebars: Generate ``sidebars.js`` in the output.
             target: Optional Flare target to build from.
             exclude_dirs: Directories to exclude from conversion.
             debug: Enable verbose logging.
@@ -53,9 +48,7 @@ class FlareConverter:
         self.input_dir = Path(input_dir)
         self.output_dir = Path(output_dir)
         self.preserve_structure = preserve_structure
-        self.use_llm = use_llm
-        self.llm_api_key = llm_api_key
-        self.llm_provider = llm_provider
+        self.generate_sidebars = generate_sidebars
         self.exclude_dirs = exclude_dirs or []
         self.debug = debug
         self.markdown_style = markdown_style
@@ -79,10 +72,6 @@ class FlareConverter:
             general_markdown=(self.markdown_style != "docusaurus"),
         )
         
-        # Initialize LLM service if requested
-        self.llm_service = None
-        if use_llm and llm_api_key:
-            self.llm_service = LlmService(api_key=llm_api_key, provider=llm_provider)
 
     def convert(self) -> Dict[str, int]:
         """
@@ -94,9 +83,6 @@ class FlareConverter:
         # Parse the Flare HTML structure
         project_structure = self.parser.parse()
         
-        # Optionally use LLM to reorganize the structure
-        if self.use_llm and self.llm_service:
-            project_structure = self.llm_service.suggest_structure(project_structure)
         
         # Filter topics based on exclude_dirs if specified
         if self.exclude_dirs:
@@ -140,8 +126,8 @@ class FlareConverter:
         # Copy assets
         self._copy_assets(project_structure.get("assets", []))
         
-        # Generate sidebar.js if needed
-        if not self.preserve_structure and self.use_llm:
+        # Generate sidebar.js if requested
+        if self.generate_sidebars:
             self._generate_sidebar(project_structure)
         
         # Print link mapping report
@@ -223,13 +209,18 @@ class FlareConverter:
         """
         for asset in assets:
             source_path = self.input_dir / asset.get("path", "")
-            
+
             if self.preserve_structure:
-                rel_path = asset.get("rel_path", asset.get("path", ""))
+                rel_path = Path(asset.get("rel_path", asset.get("path", "")))
+                # Drop any leading 'Resources' directory from the asset path
+                rel_parts = [p for p in rel_path.parts if p.lower() != "resources"]
+                rel_path = Path(*rel_parts)
                 dest_path = self.output_dir / rel_path
             else:
                 # Use new path if provided by LLM
-                dest_path = self.output_dir / asset.get("new_path", asset.get("rel_path", ""))
+                new_path = Path(asset.get("new_path", asset.get("rel_path", "")))
+                rel_parts = [p for p in new_path.parts if p.lower() != "resources"]
+                dest_path = self.output_dir / Path(*rel_parts)
             
             # Create parent directories
             os.makedirs(dest_path.parent, exist_ok=True)

--- a/flarewell/image_relocator.py
+++ b/flarewell/image_relocator.py
@@ -73,10 +73,14 @@ class ImageRelocator:
             try:
                 # Get the path relative to the source directory
                 rel_path = source_path.relative_to(self.source_dir)
-                
+
+                # Remove any 'Resources' directory from the relative path
+                rel_parts = [p for p in rel_path.parts if p.lower() != "resources"]
+                rel_path_no_res = Path(*rel_parts)
+
                 if self.preserve_structure:
-                    # Keep subdirectory structure but place in target directory
-                    target_path = self.target_dir / rel_path
+                    # Keep subdirectory structure without the Resources folder
+                    target_path = self.target_dir / rel_path_no_res
                 else:
                     # Flatten structure, just keep filename
                     target_path = self.target_dir / source_path.name
@@ -88,13 +92,15 @@ class ImageRelocator:
                 shutil.copy2(source_path, target_path)
                 
                 # Store the mapping for updating references
-                # For the key, use the relative path from source directory
-                key = str(rel_path)
-                
+                # Include both the original path and the path without 'Resources'
+                key_original = str(rel_path).replace("\\", "/")
+                key_no_res = str(rel_path_no_res).replace("\\", "/")
+
                 # For the value, calculate the relative path from source_dir to target_path
                 # This ensures consistent path resolution regardless of absolute paths
                 target_rel_path = os.path.relpath(target_path, self.source_dir)
-                self.relocated_images[key] = target_rel_path
+                self.relocated_images[key_original] = target_rel_path
+                self.relocated_images[key_no_res] = target_rel_path
                 
                 stats["images_relocated"] += 1
                 
@@ -217,8 +223,13 @@ class ImageRelocator:
             abs_path = os.path.normpath(os.path.join(current_dir, img_path)).replace('\\', '/')
         
         # Check if this image was relocated
-        if abs_path in self.relocated_images:
-            new_path = self.relocated_images[abs_path]
+        lookup_path = abs_path
+        if abs_path not in self.relocated_images and 'Resources/' in abs_path:
+            # Try again without the Resources folder
+            lookup_path = abs_path.replace('Resources/', '', 1)
+
+        if lookup_path in self.relocated_images:
+            new_path = self.relocated_images[lookup_path]
             
             # Calculate relative path from current file to the new image location
             try:

--- a/flarewell/markdown_image_cleaner.py
+++ b/flarewell/markdown_image_cleaner.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 class MarkdownImageCleaner:
     """Scan markdown files and remove references to images that do not exist."""
@@ -34,6 +34,14 @@ class MarkdownImageCleaner:
                 return match.group(0)
             abs_path = (md_file.parent / img_path_clean).resolve()
             if not abs_path.exists():
+                candidate = self._search_nearby_image(Path(img_path_clean).name)
+                if candidate:
+                    new_rel = os.path.relpath(candidate, md_file.parent).replace('\\', '/')
+                    if self.debug:
+                        print(
+                            f"Fixed missing image '{img_path_clean}' -> '{new_rel}' in {md_file}"
+                        )
+                    return f"![{match.group(1)}]({new_rel})"
                 if self.debug:
                     print(f"Removing missing image '{img_path_clean}' in {md_file}")
                 count += 1
@@ -51,6 +59,14 @@ class MarkdownImageCleaner:
                 return match.group(0)
             abs_path = (md_file.parent / img_path_clean).resolve()
             if not abs_path.exists():
+                candidate = self._search_nearby_image(Path(img_path_clean).name)
+                if candidate:
+                    new_rel = os.path.relpath(candidate, md_file.parent).replace('\\', '/')
+                    if self.debug:
+                        print(
+                            f"Fixed missing image '{img_path_clean}' -> '{new_rel}' in {md_file}"
+                        )
+                    return match.group(0).replace(img_path, new_rel)
                 if self.debug:
                     print(f"Removing missing image '{img_path_clean}' in {md_file}")
                 count += 1
@@ -61,3 +77,10 @@ class MarkdownImageCleaner:
         text = re.sub(html_img_pattern, repl_html, text)
 
         return text, count
+
+    def _search_nearby_image(self, filename: str) -> Optional[Path]:
+        """Search the docs directory for an image with the same filename."""
+        matches = list(self.docs_dir.glob(f"**/{filename}"))
+        if len(matches) == 1:
+            return matches[0]
+        return None


### PR DESCRIPTION
## Summary
- drop LLM parameters and always generate sidebars (unless disabled)
- add `--no-sidebars` and `--verbose-image-cleanup` CLI flags
- restore `_search_nearby_image` helper so image cleanup can correct nearby files
- document the new defaults and options

## Testing
- `python -m py_compile flarewell/cli.py flarewell/converter.py flarewell/image_relocator.py flarewell/markdown_image_cleaner.py flarewell/docusaurus_formatter.py flarewell/link_mapper.py flarewell/flare_parser.py`