### PR TITLE
Fix MDX build issues with malformed URLs

### DIFF
--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -59,7 +59,7 @@ class ConversionTests(unittest.TestCase):
 
     def test_aix_contains_url(self):
         content = Path(DOCS_DIR / "AIX.md").read_text()
-        self.assertIn("https://IPADDRESS-SERVERNAME:PORT/api/", content)
+        self.assertIn("`https://IPADDRESS-SERVERNAME:PORT/api/`", content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- escape malformed URLs with a new helper in the formatter
- update conversion tests to expect sanitized URLs

## Testing
- `pytest -q`
- `python -m flarewell.cli convert --input-dir tests/input_docs --output-dir tests/test_website/docs`
- `npm run build --silent --prefix tests/test_website`
