### PR TITLE
Fix CLI defaults and flatten output

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Converted images will be moved to a `static` directory next to your output docs 
 
 - `--input-dir, -i`: Directory containing Flare HTML output
 - `--output-dir, -o`: Directory to output Docusaurus-compatible Markdown files
-- `--preserve-structure`: Preserve the original folder/file structure (default: `True`)
+- `--preserve-structure`: Preserve the original folder/file structure (default: `False`)
 - `--exclude-dir`: Directory patterns to exclude from conversion (can be used multiple times)
 - `--debug`: Enable debug mode for detailed logging
 - `--no-sidebars`: Skip generating `sidebars.js`

--- a/flarewell/cli.py
+++ b/flarewell/cli.py
@@ -38,7 +38,7 @@ def cli():
 @click.option(
     "--preserve-structure",
     is_flag=True,
-    default=True,
+    default=False,
     help="Preserve the original folder/file structure."
 )
 @click.option(

--- a/flarewell/converter.py
+++ b/flarewell/converter.py
@@ -156,7 +156,11 @@ class FlareConverter:
             rel_path = file_info.get("rel_path", file_info.get("path", ""))
             output_path = self.output_dir / rel_path
         else:
-            output_path = self.output_dir / file_info.get("new_path", file_info.get("rel_path", ""))
+            new_rel = file_info.get("new_path")
+            if not new_rel:
+                rel_source = file_info.get("rel_path", file_info.get("path", ""))
+                new_rel = Path(rel_source).name
+            output_path = self.output_dir / new_rel
 
         output_path = output_path.with_suffix(".md")
 
@@ -229,10 +233,10 @@ class FlareConverter:
                 rel_path = Path(*rel_parts)
                 dest_path = self.output_dir / rel_path
             else:
-                # Use new path if provided by LLM
-                new_path = Path(asset.get("new_path", asset.get("rel_path", "")))
-                rel_parts = [p for p in new_path.parts if p.lower() != "resources"]
-                dest_path = self.output_dir / Path(*rel_parts)
+                new_rel = asset.get("new_path")
+                if not new_rel:
+                    new_rel = Path(asset.get("rel_path", asset.get("path", ""))).name
+                dest_path = self.output_dir / new_rel
             
             # Create parent directories
             os.makedirs(dest_path.parent, exist_ok=True)


### PR DESCRIPTION
## Summary
- default `--preserve-structure` flag to `False`
- update docs to reflect default
- flatten output paths when `preserve_structure` is disabled

## Testing
- `pytest -q`